### PR TITLE
uart: Remove `sleep/1` when sending ACL frames

### DIFF
--- a/lib/blue_heron/peripheral.ex
+++ b/lib/blue_heron/peripheral.ex
@@ -248,7 +248,6 @@ defmodule BlueHeron.Peripheral do
 
     if response do
       acl_response = build_l2cap_acl(handle, 0x0004, response)
-      Process.sleep(100)
       BlueHeron.acl(data.ctx, acl_response)
     end
 
@@ -275,7 +274,6 @@ defmodule BlueHeron.Peripheral do
     if response do
       acl_response = build_l2cap_acl(handle, 0x0006, response)
       BlueHeron.acl(data.ctx, acl_response)
-      Process.sleep(100)
     end
 
     {:keep_state, data, []}

--- a/lib/blue_heron/smp.ex
+++ b/lib/blue_heron/smp.ex
@@ -249,27 +249,22 @@ defmodule BlueHeron.SMP do
     # generate and send LTK using "Encryption Information" ACL message
     frame = acl(event.connection_handle, <<0x06>> <> reverse(ltk))
     BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
 
     # generate and send EDIV and RAND using "Central Identification" ACL message
     frame = acl(event.connection_handle, <<0x07, ediv::little-16>> <> reverse(rand))
     BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
 
     # generate and send IRK using "Identity Information" ACL message
     frame = acl(event.connection_handle, <<0x08>> <> reverse(irk))
     BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
 
     # generate and send BD_ADDRESS using "Identity Address Information" ACL message
     frame = acl(event.connection_handle, <<0x09, 0>> <> reverse(state.bd_address.binary()))
     BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
 
     # generate and send CSRK using "Signing Information" ACL message
     frame = acl(event.connection_handle, <<0x0A>> <> reverse(csrk))
     BlueHeron.acl(state.ctx, frame)
-    :timer.sleep(200)
 
     {:reply, nil, %{state | authenticated: true}}
   end


### PR DESCRIPTION
This change removes a fix for sending ACL frames. UART framing has been fixed and the sleep periods are no longer necessary.

This change requires the framing fix in
`blue-heron/blue_heron_transport_uart` to be applied first.

https://github.com/blue-heron/blue_heron_transport_uart/pull/8