### PR TITLE
write: Fix an issue writing long frames

### DIFF
--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -255,16 +255,8 @@ defmodule BlueHeron.GATT.Server do
         end
 
       %ExecuteWriteRequest{} ->
-        if require_permission?(state, request.handle, :write_auth) do
-          {state,
-           %ErrorResponse{
-             handle: request.handle,
-             request_opcode: request.opcode,
-             error: :insufficient_authentication
-           }}
-        else
-          write_long_characteristic_value(state, request)
-        end
+        # No auth required, prepare will catch it
+        write_long_characteristic_value(state, request)
 
       requ ->
         # Unhandled requests should be handled as errors, they stall all communication


### PR DESCRIPTION
This change fixes an issue where long write request failed. The issue was introduced during authentication.